### PR TITLE
Add link to Course Reserves page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 ## [Unreleased]
 ### Added
 -  Added our own custom error pages for 404/500 [#200](https://github.com/ualbertalib/NEOSDiscovery/issues/200)
-
+-  Link to Course Reserves page [#40](https://github.com/ualbertalib/NEOSDiscovery/issues/40)
 
 ## [1.0.49] - 2018-12-19
 ### Added 

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -3,10 +3,10 @@
     <%= render_nav_actions do |config, action|%>
       <li><%= action %></li>
     <% end %>
-    
-    <li><a href="https://myaccount.library.ualberta.ca/barcode?neos=true">Login</a></li>
-    <li><a href="https://www.neoslibraries.ca/catalogue-help/">Help</a></li>
-    <li class="last"><a href="https://goo.gl/forms/0eHLBasn4V1N1Cxp1" target="_blank">Feedback</a></li>
+    <li><%= link_to 'Course Reserves', 'https://neosreserves.library.ualberta.ca/' %></li>
+    <li><%= link_to 'Login', 'https://myaccount.library.ualberta.ca/barcode?neos=true' %></li>
+    <li><%= link_to 'Help', 'https://www.neoslibraries.ca/catalogue-help/' %></li>
+    <li class="last"><%= link_to 'Feedback', 'https://goo.gl/forms/0eHLBasn4V1N1Cxp1', target: '_blank' %></li>
   </ul>
 
 


### PR DESCRIPTION
![screenshot from 2019-01-24 15-57-10](https://user-images.githubusercontent.com/1220762/51713903-b9b88300-1ff0-11e9-957e-8a5be35563f2.png)

Also updated other links in that block to use the helper
 
fixes #40 