### PR TITLE
- No links for electronic resources for King's in new catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix for no links for electronic resources for King's [#285](https://github.com/ualbertalib/NEOSDiscovery/issues/285)
 
 ## [1.0.53] - 2019-07-09
 

--- a/config/libraries.yml
+++ b/config/libraries.yml
@@ -40,7 +40,7 @@ keyano:
   neosurl: "https://www.neoslibraries.ca/member-libraries/keyano-college-library/"
   proxy: "http://ezproxy.afmk.talonline.ca/login?url="
 kings:
-  name: "The King's University"
+  name: "King's University"
   url: "https://www.kingsu.ca/library"
   neosurl: "https://www.neoslibraries.ca/member-libraries/the-kings-university-library/"
   proxy: "http://aekc.talonline.ca/login?url="


### PR DESCRIPTION
Removed 'the' from king's unniversity name inside libraries.yml
#285