### PR TITLE
Added missing Concordia Internet Library location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 ### Added
 - Added missing pop-up and artists statuses [#257](https://github.com/ualbertalib/NEOSDiscovery/issues/257)
 - Added javascript to ensure the cursor goes to the main search box [#197](https://github.com/ualbertalib/NEOSDiscovery/issues/197)
+- Added missing Concordia Internet Library location [#304](https://github.com/ualbertalib/NEOSDiscovery/issues/304)
 
 ## [1.0.54] - 2019-07-19
 

--- a/app/views/catalog/_symphony_holdings.html.erb
+++ b/app/views/catalog/_symphony_holdings.html.erb
@@ -8,8 +8,8 @@
 
   <% @links = @urls.reduce Hash.new, :merge if @urls %>
   <% for item in @holdings.reverse %>
-    <% @locationname = @locations[item[:location].downcase.gsub("_","")]["name"] %>
-    <% @locationurl = @locations[item[:location].downcase.gsub("_","")]["locationurl"] %>
+    <% @locationname = @locations.dig(item[:location].downcase.gsub("_",""), "name") || "Unknown"%>
+    <% @locationurl = @locations.dig(item[:location].downcase.gsub("_",""), "locationurl")  %>
     <% if @locationname.include?(" - ") %>
       <% @current_loc = @locationname.split(" - ").first %>
     <% else %>
@@ -30,13 +30,13 @@
     <% if @current_loc.include? "Covenant" then @current_loc = "covenant" end %>
     <% if @current_loc.include? "Innovates" then @current_loc = "innovates" end %>
     <% @library = @libraries[@current_loc.downcase.gsub(/\s+/, "")] %>
-    <% @proxy = @library['proxy'] %>
+    <% @proxy = @library.dig('proxy') if @library%>
 
     <% @unavailable = true if @statuses[item[:status].to_s.downcase] == "unavailable" %>
     <tr>
       <td>
         <p class="lib-loc">
-          <%= @locationname %> 
+          <%= @locationname %>
           <% if @locationurl %>
             <a href="<%= @locationurl %>" target="_blank">
               <span class="glyphicon glyphicon-info-sign">
@@ -46,14 +46,14 @@
         </p>
         <% if @links %>
          <% @links.each{|name,link| %>
-            <% if (name.include?(@library["name"])) %>
+            <% if @library && (name.include?(@library["name"])) %>
               <% @current_link = "#{@proxy}#{link}" %>
               <% if item[:call] == "Internet Access" %>
                 <strong><a href="<%= @current_link %>" target="_blank" class="loc-call"><span class="glyphicon glyphicon-share-alt"></span> Click here for Internet Access</a></strong><p style="font-size:10pt;">(<%= name %>)</p>
               <% end %>
             <% end %>
           <% } %>
-          <span class="loc-call"><span class="a-label">call number: </span><%= item[:call] %></span> 
+          <span class="loc-call"><span class="a-label">call number: </span><%= item[:call] %></span>
           <% @links.each{|name,link| %>
             <% if (name.include?("NEOS")) or (name.include?("Free")) or (name.include?("NEOS")) then %>
               <% @current_link = "#{@proxy}#{link}" %>
@@ -69,10 +69,10 @@
           <% if item[:call] == "Internet Access" %>
             <strong><a href="<%= @current_link %>" target="_blank" class="loc-call"><span class="glyphicon glyphicon-share-alt"></span> Click here for Internet Access</a></strong></td>
           <% else %>
-            <span class="loc-call"><span class="a-label">call number: </span><%= item[:call] %></span> 
+            <span class="loc-call"><span class="a-label">call number: </span><%= item[:call] %></span>
           <% end %>
         <% end %>
-        
+
         <div class="statuses">
           <span class="a-label">status: </span>
           <% if item[:status] == "CHECKEDOUT" %>

--- a/config/locations.yml
+++ b/config/locations.yml
@@ -1,11 +1,11 @@
 # from https://github.com/ualbertalib/discovery/blob/master/config/locations.yml and https://www.neoslibraries.ca/member-libraries
-aegeo:  
+aegeo:
   name: "Alberta Geological Survey"
   locationurl: "http://ags.aer.ca/about-the-ags/contact-us.htm"
-aginternet:  
+aginternet:
   name: "Alberta Government Library - Internet"
   locationurl: "https://www.servicealberta.ca/alberta-government-library.cfm"
-aglcap:  
+aglcap:
   name: "Alberta Government Library - Capital Boulevard"
   locationurl: "https://www.servicealberta.ca/alberta-government-library.cfm"
 aglcom:
@@ -32,16 +32,16 @@ agltpn:
 ahsach:
   name: "Alberta Health Services - Alberta Children's Hospital"
   locationurl: "http://krs.libguides.com/aboutus/ach"
-ahsrah:  
+ahsrah:
   name: "Alberta Health Services - Royal Alexandra Hospital"
-  locationurl: 
+  locationurl:
 ahskec:
   name: "Alberta Health Services - Kaye Edmonton Clinic"
   locationurl: "https://krs.libguides.com/aboutus/kec"
 ahsreddr:
   name: "Alberta Health Services - Red Deer Regional Hospital"
   locationurl: "https://krs.libguides.com/aboutus/rdrh"
-ahsrvgh:  
+ahsrvgh:
   name: "Alberta Health Services - Rockyview General Hospital"
   locationurl: "https://krs.libguides.com/aboutus/rgh"
 ahstbcc:
@@ -50,7 +50,7 @@ ahstbcc:
 ahsint:
   name: "Alberta Health Services/Covenant Health - Internet"
   locationurl: "https://krs.libguides.com/home"
-ahsglenrse:   
+ahsglenrse:
   name: "Alberta Health Services - Glenrose Rehabilitation Hospital"
   locationurl: "https://krs.libguides.com/aboutus/grh"
 aitfcalg:
@@ -64,7 +64,7 @@ aitfc-fer:
   locationurl: "https://www.neoslibraries.ca/member-libraries/alberta-innovates/c-fer-library"
 aitfdevon:
   name: "Alberta Innovates - Technology Futures - Devon"
-  locationurl: 
+  locationurl:
 aitfmw:
   name: "Alberta Innovates - Technology Futures - Mill Woods"
   locationurl: "https://www.neoslibraries.ca/member-libraries/alberta-innovates/mill-woods-library/"
@@ -77,22 +77,25 @@ burman:
 concordia:
   name: "Concordia University of Edmonton"
   locationurl: "http://library.concordia.ab.ca"
-concordsem:   
+concordin:
+  name: "Concordia Internet Library"
+  locationurl: "https://concordia.ab.ca/library/"
+concordsem:
   name: "Concordia Lutheran Seminary"
   locationurl: "http://www.concordiasem.ab.ca/research/library_information.php"
-covenantgn: 
+covenantgn:
   name: "Covenant Health - Grey Nuns Community Hospital"
   locationurl: "​https://www.covenanthealth.ca/corporate-information/library-services​"
-covenantmh:   
+covenantmh:
   name: "Covenant Health - Misericordia Community Hospital"
   locationurl: "​https://www.covenanthealth.ca/corporate-information/library-services​"
 gprcgp:
   name: "Grande Prairie Regional College - Grande Prairie"
   locationurl: "https://www.gprc.ab.ca/library"
-gprcfrvw:   
+gprcfrvw:
   name: "Grande Prairie Regional College - Fairview"
   locationurl: "https://www.gprc.ab.ca/library"
-gprcint:   
+gprcint:
   name: "Grande Prairie Regional College - Internet"
   locationurl: "https://www.gprc.ab.ca/library"
 grmacacc:
@@ -113,10 +116,10 @@ grmacsoc:
 grmacewan:
   name: "MacEwan University - City Centre Campus"
   locationurl: "https://library.macewan.ca/"
-justiceca:   
+justiceca:
   name: "Justice Canada"
-  locationurl: 
-keyano:   
+  locationurl:
+keyano:
   name: "Keyano College"
   locationurl: "http://www.keyano.ca/Services/Library​"
 kings:
@@ -133,8 +136,8 @@ lakelndvr:
   locationurl: "https://www.neoslibraries.ca/member-libraries/lakeland/vermilion-campus-library/​"
 neosfree:
   name: "NEOS Free Internet Resources"
-  locationurl: 
-newman:   
+  locationurl:
+newman:
   name: "Newman Theological College"
   locationurl: "https://www.newman.edu/Library"
 nlcgr:
@@ -149,7 +152,7 @@ nlcsl:
 norqmain:
   name: "NorQuest College - Main Building"
   locationurl: "https://library.norquest.ca"
-norqwest:   
+norqwest:
   name: "NorQuest College - Westmount"
   locationurl: "https://library.norquest.ca"
 olds:
@@ -182,7 +185,7 @@ uabusiness:
 uaeduc:
   name: "University of Alberta HT Coutts Education"
   locationurl: "https://www.library.ualberta.ca/locations/coutts"
-uahlthsc:   
+uahlthsc:
   name: "University of Alberta JW Scott Health Sciences"
   locationurl: "https://www.library.ualberta.ca/locations/scott"
 uahss:


### PR DESCRIPTION
500 error thrown on selected e-resource records where this value couldn't be mapped
`item[:location] in @locations`

Also prevents a similar future error from throwing 500s.

![Screenshot from 2019-10-29 14-36-10](https://user-images.githubusercontent.com/1220762/67807170-e60a9f80-fa59-11e9-9be7-80ac56e2d110.png)
![Screenshot from 2019-10-29 14-39-40](https://user-images.githubusercontent.com/1220762/67807208-f884d900-fa59-11e9-8086-34c5fa940c6a.png)


#304