### PR TITLE
add rollbar proxy initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ### Added
 - add regression tests [PR#330][https://github.com/ualbertalib/NEOSDiscovery/pull/330]
+- add initialization for rollbar proxy [#271](https://github.com/ualbertalib/NEOSDiscovery/issues/271)
 
 ### Changed
 - change what appears in the open search description [#258](https://github.com/ualbertalib/NEOSDiscovery/issues/258)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -51,12 +51,12 @@ Rollbar.configure do |config|
   # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
   # are optional.
   #
-  # config.proxy = {
-  #   host: 'http://some.proxy.server',
-  #   port: 80,
+  config.proxy = {
+    host: Rails.application.secrets.rollbar_proxy_host,
+    port: Rails.application.secrets.rollbar_proxy_port
   #   user: 'username_if_auth_required',
   #   password: 'password_if_auth_required'
-  # }
+  }
 
   # If you run your staging application instance in production environment then
   # you'll want to override the environment reported by `Rails.env` with an

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -21,3 +21,5 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   rollbar_token: <%= ENV['ROLLBAR_TOKEN'] %>
+  rollbar_proxy_host: <%= ENV['PROXY_HOST'] %>
+  rollbar_proxy_port: <%= ENV['PROXY_PORT'] %>


### PR DESCRIPTION
NEOSDiscovery lives behind a proxy because security.  In order for rollbar
messages to get out it needs to know about the proxy. Configuration management
is done with ansible so we use secrets.yml as a place to config the environment
variables rather than some convoluted path through apache/passenger.

https://docs.rollbar.com/docs/ruby#section-web-proxies

#271 