### PR TITLE
Add version file and meta generator tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 ### Added
 - add regression tests [PR#330][https://github.com/ualbertalib/NEOSDiscovery/pull/330]
 - add initialization for rollbar proxy [#271](https://github.com/ualbertalib/NEOSDiscovery/issues/271)
+- Add version file and meta generator tag 
 
 ### Changed
 - change what appears in the open search description [#258](https://github.com/ualbertalib/NEOSDiscovery/issues/258)

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -7,7 +7,7 @@
     <!-- Mobile viewport optimization h5bp.com/ad -->
     <meta name="HandheldFriendly" content="True">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    
+
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -15,6 +15,9 @@
     <!--[if IEMobile]>
       <meta http-equiv="cleartype" content="on">
     <![endif]-->
+
+
+    <meta name="generator" content="<%= "NEOS Discovery #{SearchApp::VERSION} - https://github.com/ualbertalib/NEOSDiscovery" %>">
 
     <title>NEOS Catalogue</title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,8 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module SearchApp
+  VERSION = '1.0.58'.freeze # used in application layout meta generator tag
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
It's hard to know which version of the code you're looking at.
If we can keep this up-to-date in our release management then we'll be
able to tell which version we see deployed by checking the page source.

Similar to https://github.com/ualbertalib/discovery/issues/1343