### PR TITLE
fix "The Economist" rollbar error, short_code normalization, and an undeclared e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+### Fixed
+-  "The Economist" rollbar error, short_code normalization, and an undeclared e [PR#375](https://github.com/ualbertalib/NEOSDiscovery/pull/375)
+
 ## [1.0.58] - 2020-02-25
 
 ### Security

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -42,7 +42,7 @@ module HoldingsHelper
       name = 'Concordia University of Edmonton'
     end
 
-    # :links will get all the links, at this point we want just the one that matches
+    # @urls has ALL the links, at this point we want just the one that matches
     # the name we passed or the free resource
     @urls&.inject(:merge)&.select do |k|
       free?(k) || name.include?(k.partition(' Access ').first)

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -20,7 +20,7 @@ module HoldingsHelper
   def location(item)
     @location ||= Hash.new do |h, key|
       location = Location.includes(:library).find_by(short_code: key) || begin
-        Rollbar.error("Error retriving name for Location #{key}", e)
+        Rollbar.error("Error retriving name for Location #{key}")
         Location.create(
           short_code: key,
           name: 'Unknown'
@@ -29,10 +29,10 @@ module HoldingsHelper
       h[key] = {
         name:  location.name,
         url:   location.url,
-        proxy: location.library.proxy
+        proxy: location.library&.proxy
       }
     end
-    @location[item[:location].downcase.delete('_').to_sym]
+    @location[item[:location]]
   end
 
   def links(name)
@@ -44,7 +44,7 @@ module HoldingsHelper
 
     # :links will get all the links, at this point we want just the one that matches
     # the name we passed or the free resource
-    holdings(@document, :links).inject(:merge).select do |k|
+    @urls&.inject(:merge)&.select do |k|
       free?(k) || name.include?(k.partition(' Access ').first)
     end || {}
   end

--- a/db/migrate/20200513220209_change_location_short_code.rb
+++ b/db/migrate/20200513220209_change_location_short_code.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class ChangeLocationShortCode < ActiveRecord::Migration[5.2]
+  CODES = {
+    'aginternet' => 'AGINTERNET',
+    'aglcap' => 'AGL_CAP',
+    'ahsach' => 'AHS_ACH',
+    'ahskec' => 'AHS_KEC',
+    'ahsreddr' => 'AHS_REDDR',
+    'ahsrvgh' => 'AHS_RVGH',
+    'ahstbcc' => 'AHS_TBCC',
+    'ahsint' => 'AHS_INT',
+    'ahsglenrse' => 'AHSGLENRSE',
+    'aitfcfer' => 'AITF_C-FER',
+    'aitfmw' => 'AITF_MW',
+    'aitfveg' => 'AITF_VEG',
+    'burman' => 'BURMAN',
+    'concordia' => 'CONCORDIA',
+    'concordsem' => 'CONCORDSEM',
+    'covenantgn' => 'COVENANTGN',
+    'covenantmh' => 'COVENANTMH',
+    'gprcgp' => 'GPRC_GP',
+    'gprcfrvw' => 'GPRC_FRVW',
+    'gprcint' => 'GPRC_INT',
+    'grmacacc' => 'GR_MAC_ACC',
+    'grmacint' => 'GR_MAC_INT',
+    'grmactsv' => 'GR_MAC_TSV',
+    'grmacewan' => 'GR_MACEWAN',
+    'keyano' => 'KEYANO',
+    'kings' => 'KINGS',
+    'lakelndin' => 'LAKELND_IN',
+    'lakelndll' => 'LAKELND_LL',
+    'lakelndvr' => 'LAKELND_VR',
+    'neosfree' => 'NEOS_FREE',
+    'newman' => 'NEWMAN',
+    'nlcgr' => 'NLC_GR',
+    'nlcint' => 'NLC_INT',
+    'nlcsl' => 'NLC_SL',
+    'norqmain' => 'NORQ_MAIN',
+    'norqwest' => 'NORQ_WEST',
+    'olds' => 'OLDS',
+    'reddeerc' => 'RED_DEER_C',
+    'taylor' => 'TAYLOR',
+    'vanguard' => 'VANGUARD',
+    'uaarchives' => 'UAARCHIVES',
+    'uaaug' => 'UAAUG',
+    'uabsj' => 'UABSJ',
+    'uabusiness' => 'UABUSINESS',
+    'uaeduc' => 'UAEDUC',
+    'uahlthsc' => 'UAHLTHSC',
+    'uahss' => 'UAHSS',
+    'uainternet' => 'UAINTERNET',
+    'ualaw' => 'UALAW',
+    'uamath' => 'UAMATH',
+    'uascitech' => 'UASCITECH',
+    'uasjc' => 'UASJC',
+    'uaspcoll' => 'UASPCOLL',
+    'uatechserv' => 'UATECHSERV',
+    'uarcrf' => 'UARCRF'
+  }.freeze
+
+  def up
+    CODES.each do |old_code, new_code|
+      entry = Location.find_or_initialize_by(short_code: old_code)
+      entry.short_code = new_code
+      entry.save
+    end
+  end
+
+  def down
+    CODES.invert.each do |old_code, new_code|
+      entry = Location.find_or_initialize_by(short_code: old_code)
+      entry.short_code = new_code
+      entry.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_224334) do
+ActiveRecord::Schema.define(version: 2020_05_13_220209) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
I suspect this was the [priority NEOSDiscovery performance error](https://github.com/ualbertalib/discovery/issues/1951). #354 
catalog/1698093 demonstrated two separate but related bugs.

The first bug was that HoldingsHelper#links repeated the call to Symphony
for each of the items in the holdings table rather than using the @urls
instance variable declared in the controller.

The second bug was that HoldingsHelper#links assumes that there always are
links when (for example the Economist) there may not be any.

While investigating this there appeared to be an inconsistency in the
normalization of Location short_codes.  I have migrated the Location short codes
so that there isn't any conversion by the application.  This matches Discovery.

Additionally this removes an undeclared var e in on of the rollbar messages.