### PR TITLE
add safe navigation operator to location_tesim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 ## [Unreleased]
 
 ### Fixed
-- safe navigation operator for potential location_tesim [PR#383](https://github.com/ualbertalib/NEOSDiscovery/pull/383)
+- safe navigation operator for potential nil location_tesim [PR#383](https://github.com/ualbertalib/NEOSDiscovery/pull/383)
 
 ## [1.0.60] - 2020-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+### Fixed
+- safe navigation operator for potential location_tesim [PR#383](https://github.com/ualbertalib/NEOSDiscovery/pull/383)
+
 ## [1.0.60] - 2020-05-28
 
 ### Security 

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -13,7 +13,7 @@
 <% if document.to_h["source_tesim"] and document.to_h["source_tesim"].first == "Symphony" %> 
   <dt class="blacklight-format">Copies owned by: </dt>
   <dd class="blacklight-format">
-    <%= document["location_tesim"].join(', ') %>
+    <%= document["location_tesim"]&.join(', ') %>
   </dd>
 <% end %>
   <% end %>


### PR DESCRIPTION
Experienced `undefined method 'join' for nil:NilClass` 

While using https://github.com/ualbertalib/discovery/blob/master/spec/fixtures/subset.mrc to build an index with institutions and libraries from the database populated from Symphony information result in scant records revealing that the assumption this will be not nill.