### PR TITLE
[Spike] CirculationRules and ItemType models to align with Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+### Added
+- CirculationRules and ItemType models to align with Discovery []()
+
 ## [1.0.66] - 2021-01-13
 
 ### Changed

--- a/app/models/circulation_rule.rb
+++ b/app/models/circulation_rule.rb
@@ -1,0 +1,2 @@
+class CirculationRule < ActiveRecord::Base
+end

--- a/app/models/item_type.rb
+++ b/app/models/item_type.rb
@@ -1,0 +1,2 @@
+class ItemType < ActiveRecord::Base
+end

--- a/db/migrate/20210129164841_create_item_types.rb
+++ b/db/migrate/20210129164841_create_item_types.rb
@@ -1,0 +1,9 @@
+class CreateItemTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_types do |t|
+      t.string :short_code
+      t.string :name
+         t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20210129164854_create_circulation_rules.rb
+++ b/db/migrate/20210129164854_create_circulation_rules.rb
@@ -1,0 +1,10 @@
+class CreateCirculationRules < ActiveRecord::Migration[5.2]
+  def change
+    create_table :circulation_rules do |t|
+      t.string :short_code
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
Both Discovery and NEOSDiscovery use Symphony configuration data to provide human readable string in the holding table.  Additionaly NEOSDiscovery has library/location relationships.  We now have this data flowing into Discovery but we need this to continue to flow into NEOSDiscovery.  One way to do this would be to use the same migrations on both applications.

Here we create two tables that will not be used by the application in the interest of being compatible with Discovery symphony_nightly migrations.

https://github.com/ualbertalib/NEOSDiscovery/issues/352