### PR TITLE
[SPIKE] Try the mysqldump method to share Symphony data

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,9 +5,12 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
+  adapter: mysql2
+  encoding: utf8
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password: <%= ENV['DISCOVERY_DATABASE_PASSWORD'] || 'mysecretpassword' %> 
+  host: 127.0.0.1
 
 development:
   <<: *default


### PR DESCRIPTION
Both Discovery and NEOSDiscovery use Symphony configuration data to provide human readable string in the holding table.  Additionaly NEOSDiscovery has library/location relationships.  We now have this data flowing into Discovery but we need this to continue to flow into NEOSDiscovery.  One way to do this would be to dump and load the data from one db to the other.

`mysqldump -p discovery_development statuses libraries locations > discovery_dump.sql`
`mysqldump development < discovery_dump.sql`

https://github.com/ualbertalib/NEOSDiscovery/issues/352