### PR TITLE
Silence blacklight deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+## [1.0.68] - 2021-04-06
 
 ### Changed
 - silence blacklight deprecation warnings [#135](https://github.com/ualbertalib/NEOSDiscovery/issues/135)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+
+### Changed
+- silence blacklight deprecation warnings [#135](https://github.com/ualbertalib/NEOSDiscovery/issues/135)
+
 ## [1.0.67] - 2021-04-06
 
 ### Changed

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module SearchApp
-  VERSION = '1.0.67'.freeze # used in application layout meta generator tag
+  VERSION = '1.0.68'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/blacklight_deprecations.rb
+++ b/config/initializers/blacklight_deprecations.rb
@@ -1,0 +1,1 @@
+Deprecation.default_deprecation_behavior = :silence


### PR DESCRIPTION
Whenever a crawler visits https://catalogue.neoslibraries.ca/, in part due to the verbose deprecation warnings, the logs fill up disk space and cause headaches for our UNIX team.  Turning off this noise is something that we can do to help.

Before:
```
pgwillia@CARBON:~/Code/ualbertalib/NEOSDiscovery$ rails s
/home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/railties-6.1.3/lib/rails/app_loader.rb:53: warning: Insecure world writable dir /mnt/c in PATH, mode 040777
/home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:200: warning: constant Gem::ConfigMap is deprecated
=> Booting WEBrick
=> Rails 5.2.5 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
[2021-04-16 14:58:00] INFO  WEBrick 1.4.2
[2021-04-16 14:58:00] INFO  ruby 2.6.6 (2020-03-31) [x86_64-linux]
[2021-04-16 14:58:00] INFO  WEBrick::HTTPServer#start: pid=4744 port=3000
Started GET "/catalog/1001408?lib=universityofalberta" for 127.0.0.1 at 2021-04-16 14:58:01 -0600
   (1.4ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by CatalogController#show as HTML
  Parameters: {"lib"=>"universityofalberta", "id"=>"1001408"}
/mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/models/solr_document.rb:54: warning: key :AU is duplicated and overwritten on line 55
/mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/models/solr_document.rb:61: warning: key :SN is duplicated and overwritten on line 62
Solr query: get select {:qt=>"document", :id=>"1001408"}
Solr fetch (727.8ms)
  Search Load (1.5ms)  SELECT  "searches".* FROM "searches" WHERE "searches"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND "searches"."id" = ? ORDER BY updated_at desc LIMIT ?  [["id", 10], ["id", 9], ["id", 8], ["id", 7], ["id", 6], ["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1], ["id", 3], ["id", 2], ["id", 1], ["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1], ["id", 10], ["LIMIT", 1]]
Solr query: get select {"qt"=>nil, "facet.field"=>["electronic_tesim", "institution_tesim", "location_tesim", "lc_1letter_facet", "format", "pub_date", "author_display", "subject_topic_facet", "language_facet", "subject_geo_facet", "subject_era_facet"], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["{!term f=location_tesim}University of Alberta Mathematics", "source:Symphony"], "hl.fl"=>[], "rows"=>2, "q"=>"\"Haario, H.", "facet"=>false, "f.institution_tesim.facet.sort"=>"index", "f.location_tesim.facet.sort"=>"index", "f.lc_1letter_facet.facet.limit"=>11, "f.format.facet.limit"=>11, "f.author_display.facet.limit"=>21, "f.subject_topic_facet.facet.limit"=>21, "f.language_facet.facet.limit"=>11, "f.subject_geo_facet.facet.limit"=>11, "f.subject_era_facet.facet.limit"=>11, "sort"=>"score desc, pub_date_sort desc, title_sort asc", "stats"=>"true", "stats.field"=>["pub_date"], "fl"=>"*"}
Solr fetch (25.5ms)
  Library Load (1.5ms)  SELECT  "libraries".* FROM "libraries" WHERE "libraries"."short_code" = ? LIMIT ?  [["short_code", "universityofalberta"], ["LIMIT", 1]]
  Rendering catalog/show.html.erb within layouts/blacklight
  Rendered catalog/_previous_next_doc.html.erb (24.3ms)
  User Load (1.5ms)  SELECT  "users".* FROM "users" WHERE "users"."email" = ? LIMIT ?  [["email", "guest_-wDu1njeibKG3tDFB8xs_1611966479_1@example.com"], ["LIMIT", 1]]
  Bookmark Load (1.3ms)  SELECT "bookmarks".* FROM "bookmarks" WHERE "bookmarks"."user_id" = ? AND "bookmarks"."user_type" = ? AND "bookmarks"."document_type" = ? AND "bookmarks"."document_id" = ?  [["user_id", 1], ["user_type", "User"], ["document_type", "SolrDocument"], ["document_id", "1001408"]]
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_bookmark_control.html.erb (120.9ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (12.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.2ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.2ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.2ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.4ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.3ms)
  Rendered catalog/_correction_form.html.erb (0.4ms)
Looking for document partial show_header_list_book
Looking for document partial show_header_list_default
Looking for document partial show_header_book
Looking for document partial show_header_default
Looking for document partial show_list_book
Looking for document partial show_list_default
Looking for document partial show_book
Looking for document partial show_default
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
DEPRECATION WARNING: render_document_show_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by ShowPresenter#field_value). (called from block in _app_views_catalog__show_default_html_erb___4001506537402568976_70169739085700 at /mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/views/catalog/_show_default.html.erb:34)
DEPRECATION WARNING: render_field_value is deprecated and will be removed from Blacklight version 7.0.0 (replaced by IndexPresenter#field_value). (called from render_document_show_field_value at /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/helpers/blacklight/blacklight_helper_behavior.rb:226)
  Rendered catalog/_subjects.html.erb (0.5ms)
  Location Load (1.7ms)  SELECT  "locations".* FROM "locations" WHERE "locations"."short_code" = ? LIMIT ?  [["short_code", "UASCITECH"], ["LIMIT", 1]]
  Library Load (1.2ms)  SELECT "libraries".* FROM "libraries" WHERE "libraries"."id" = ?  [["id", 17]]
  Status Load (2.2ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."short_code" = ? LIMIT ?  [["short_code", "restricted"], ["LIMIT", 1]]
  Rendered catalog/_symphony_holdings.html.erb (158.4ms)
  Rendered catalog/show.html.erb within layouts/blacklight (1838.4ms)
   (1.3ms)  SELECT COUNT(*) FROM "bookmarks" WHERE "bookmarks"."user_id" = ? AND "bookmarks"."user_type" = ?  [["user_id", 1], ["user_type", "User"]]
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/blacklight/nav/_bookmark.html.erb (2.6ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/blacklight/nav/_search_history.html.erb (0.7ms)
  Rendered _user_util_links.html.erb (53.8ms)
  Rendered shared/_header_navbar.html.erb (118.4ms)
  Rendered shared/_ajax_modal.html.erb (0.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/_flash_msg.html.erb (40.3ms)
  Rendered shared/_footer.html.erb (37.7ms)
Completed 200 OK in 6616ms (Views: 5383.5ms | ActiveRecord: 41.2ms)


127.0.0.1 - - [16/Apr/2021:14:58:00 MDT] "GET /catalog/1001408?lib=universityofalberta HTTP/1.1" 200 11358
http://localhost:3000/?f%5Blocation_tesim%5D%5B%5D=University+of+Alberta+Mathematics&lib=universityofalberta&q=%22Haario%2C+H. -> /catalog/1001408?lib=universityofalberta
Started GET "/assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js" for 127.0.0.1 at 2021-04-16 14:58:09 -0600
127.0.0.1 - - [16/Apr/2021:14:58:09 MDT] "GET /assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js HTTP/1.1" 304 0
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js
Started GET "/assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg" for 127.0.0.1 at 2021-04-16 14:58:10 -0600
Started GET "/assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg" for 127.0.0.1 at 2021-04-16 14:58:10 -0600
127.0.0.1 - - [16/Apr/2021:14:58:10 MDT] "GET /assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg HTTP/1.1" 200 33895
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg
127.0.0.1 - - [16/Apr/2021:14:58:10 MDT] "GET /assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg HTTP/1.1" 200 28287
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg
127.0.0.1 - - [16/Apr/2021:14:58:10 MDT] "GET /favicon.ico HTTP/1.1" 200 5430
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /favicon.ico
^C[2021-04-16 14:58:11] INFO  going to shutdown ...
[2021-04-16 14:58:12] INFO  WEBrick::HTTPServer#start done.
Exiting
```
After:
```
pgwillia@CARBON:~/Code/ualbertalib/NEOSDiscovery$ rails s
/home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/railties-6.1.3/lib/rails/app_loader.rb:53: warning: Insecure world writable dir /mnt/c in PATH, mode 040777
/home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:200: warning: constant Gem::ConfigMap is deprecated
=> Booting WEBrick
=> Rails 5.2.5 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
[2021-04-16 14:58:20] INFO  WEBrick 1.4.2
[2021-04-16 14:58:20] INFO  ruby 2.6.6 (2020-03-31) [x86_64-linux]
[2021-04-16 14:58:20] INFO  WEBrick::HTTPServer#start: pid=4875 port=3000
Started GET "/catalog/1001408?lib=universityofalberta" for 127.0.0.1 at 2021-04-16 14:58:22 -0600
   (1.6ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by CatalogController#show as HTML
  Parameters: {"lib"=>"universityofalberta", "id"=>"1001408"}
/mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/models/solr_document.rb:54: warning: key :AU is duplicated and overwritten on line 55
/mnt/c/Users/pgwillia/Code/ualbertalib/NEOSDiscovery/app/models/solr_document.rb:61: warning: key :SN is duplicated and overwritten on line 62
Solr query: get select {:qt=>"document", :id=>"1001408"}
Solr fetch (763.6ms)
  Search Load (1.5ms)  SELECT  "searches".* FROM "searches" WHERE "searches"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND "searches"."id" = ? ORDER BY updated_at desc LIMIT ?  [["id", 10], ["id", 9], ["id", 8], ["id", 7], ["id", 6], ["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1], ["id", 3], ["id", 2], ["id", 1], ["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1], ["id", 10], ["LIMIT", 1]]
Solr query: get select {"qt"=>nil, "facet.field"=>["electronic_tesim", "institution_tesim", "location_tesim", "lc_1letter_facet", "format", "pub_date", "author_display", "subject_topic_facet", "language_facet", "subject_geo_facet", "subject_era_facet"], "facet.query"=>[], "facet.pivot"=>[], "fq"=>["{!term f=location_tesim}University of Alberta Mathematics", "source:Symphony"], "hl.fl"=>[], "rows"=>2, "q"=>"\"Haario, H.", "facet"=>false, "f.institution_tesim.facet.sort"=>"index", "f.location_tesim.facet.sort"=>"index", "f.lc_1letter_facet.facet.limit"=>11, "f.format.facet.limit"=>11, "f.author_display.facet.limit"=>21, "f.subject_topic_facet.facet.limit"=>21, "f.language_facet.facet.limit"=>11, "f.subject_geo_facet.facet.limit"=>11, "f.subject_era_facet.facet.limit"=>11, "sort"=>"score desc, pub_date_sort desc, title_sort asc", "stats"=>"true", "stats.field"=>["pub_date"], "fl"=>"*"}
Solr fetch (23.1ms)
  Library Load (1.7ms)  SELECT  "libraries".* FROM "libraries" WHERE "libraries"."short_code" = ? LIMIT ?  [["short_code", "universityofalberta"], ["LIMIT", 1]]
  Rendering catalog/show.html.erb within layouts/blacklight
  Rendered catalog/_previous_next_doc.html.erb (22.5ms)
  User Load (2.4ms)  SELECT  "users".* FROM "users" WHERE "users"."email" = ? LIMIT ?  [["email", "guest_-wDu1njeibKG3tDFB8xs_1611966479_1@example.com"], ["LIMIT", 1]]
  Bookmark Load (1.3ms)  SELECT "bookmarks".* FROM "bookmarks" WHERE "bookmarks"."user_id" = ? AND "bookmarks"."user_type" = ? AND "bookmarks"."document_type" = ? AND "bookmarks"."document_id" = ?  [["user_id", 1], ["user_type", "User"], ["document_type", "SolrDocument"], ["document_id", "1001408"]]
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_bookmark_control.html.erb (127.7ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (11.5ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.2ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.2ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.4ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/catalog/_document_action.html.erb (0.4ms)
  Rendered catalog/_correction_form.html.erb (0.3ms)
Looking for document partial show_header_list_book
Looking for document partial show_header_list_default
Looking for document partial show_header_book
Looking for document partial show_header_default
Looking for document partial show_list_book
Looking for document partial show_list_default
Looking for document partial show_book
Looking for document partial show_default
  Rendered catalog/_subjects.html.erb (0.5ms)
  Location Load (1.6ms)  SELECT  "locations".* FROM "locations" WHERE "locations"."short_code" = ? LIMIT ?  [["short_code", "UASCITECH"], ["LIMIT", 1]]
  Library Load (1.1ms)  SELECT "libraries".* FROM "libraries" WHERE "libraries"."id" = ?  [["id", 17]]
  Status Load (1.9ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."short_code" = ? LIMIT ?  [["short_code", "restricted"], ["LIMIT", 1]]
  Rendered catalog/_symphony_holdings.html.erb (159.4ms)
  Rendered catalog/show.html.erb within layouts/blacklight (1919.6ms)
   (1.3ms)  SELECT COUNT(*) FROM "bookmarks" WHERE "bookmarks"."user_id" = ? AND "bookmarks"."user_type" = ?  [["user_id", 1], ["user_type", "User"]]
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/blacklight/nav/_bookmark.html.erb (2.8ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/blacklight/nav/_search_history.html.erb (0.8ms)
  Rendered _user_util_links.html.erb (58.9ms)
  Rendered shared/_header_navbar.html.erb (117.2ms)
  Rendered shared/_ajax_modal.html.erb (0.3ms)
  Rendered /home/pgwillia/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/blacklight-6.10.1/app/views/_flash_msg.html.erb (46.5ms)
  Rendered shared/_footer.html.erb (25.2ms)
Completed 200 OK in 5941ms (Views: 4667.4ms | ActiveRecord: 43.7ms)


127.0.0.1 - - [16/Apr/2021:14:58:21 MDT] "GET /catalog/1001408?lib=universityofalberta HTTP/1.1" 200 11358
http://localhost:3000/?f%5Blocation_tesim%5D%5B%5D=University+of+Alberta+Mathematics&lib=universityofalberta&q=%22Haario%2C+H. -> /catalog/1001408?lib=universityofalberta
Started GET "/assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js" for 127.0.0.1 at 2021-04-16 14:58:30 -0600
127.0.0.1 - - [16/Apr/2021:14:58:30 MDT] "GET /assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js HTTP/1.1" 304 0
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/application.debug-4eb478e15b18f7301ce1f891292439387b3df92a439c647a12b384fb8ab37030.js
Started GET "/assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg" for 127.0.0.1 at 2021-04-16 14:58:30 -0600
Started GET "/assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg" for 127.0.0.1 at 2021-04-16 14:58:30 -0600
127.0.0.1 - - [16/Apr/2021:14:58:30 MDT] "GET /assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg HTTP/1.1" 200 33895
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/universityofalberta-66c23779105aca65d99559591c63cb7103398a2a8e030b386528a64e51bcd122.jpg
127.0.0.1 - - [16/Apr/2021:14:58:30 MDT] "GET /assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg HTTP/1.1" 200 28287
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /assets/neos-logo-d31dcc3354fbddb7076c447a3b4c14673181ec0022fbdf15450994ab897076f8.jpg
127.0.0.1 - - [16/Apr/2021:14:58:30 MDT] "GET /favicon.ico HTTP/1.1" 200 5430
http://localhost:3000/catalog/1001408?lib=universityofalberta -> /favicon.ico
^C[2021-04-16 14:58:36] INFO  going to shutdown ...
[2021-04-16 14:58:36] INFO  WEBrick::HTTPServer#start done.
Exiting
```