### PR TITLE
Maintain branding across advanced search (and all actions) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+## [1.0.70] - 2021-08-25
+
 ### Fixed
 - Maintain branding across advanced search (and all actions) [OTRS#61391](https://helpdesk.library.ualberta.ca/otrs/index.pl?Action=AgentTicketZoom;TicketID=61391)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+### Fixed
+- Maintain branding across advanced search (and all actions) [OTRS#61391](https://helpdesk.library.ualberta.ca/otrs/index.pl?Action=AgentTicketZoom;TicketID=61391)
+
 ## [1.0.69] - 2021-05-05
 
 ### Security

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,34 +9,18 @@ class CatalogController < ApplicationController
   include HoldingsHelper
   include Blacklight::Ris::Catalog
 
+  before_action :branding
+
   def index
     super
-    library = begin
-      Library.find_by!(short_code: params[:lib])
-    rescue ActiveRecord::RecordNotFound
-      Library.find_by!(short_code: 'neos')
-    end
-    $brand = library.short_code
-    $libraryname = library.name
-    $homeurl = library.url
-    $neosurl = library.neos_url
 
     @neos_libraries = Library.all
-           .reject { |library| free?(library.name) }
-           .sort_by(&:name)
+                             .reject { |library| free?(library.name) }
+                             .sort_by(&:name)
   end
 
   def show
     super
-    library = begin
-      Library.find_by!(short_code: params[:lib])
-    rescue ActiveRecord::RecordNotFound
-      Library.find_by!(short_code: 'neos')
-    end
-    $brand = library.short_code
-    $libraryname = library.name
-    $homeurl = library.url
-    $neosurl = library.neos_url
 
     @holdings = []
     @holdings = holdings(@document, :items)
@@ -57,9 +41,21 @@ class CatalogController < ApplicationController
       end
     end
 
-    if @document['author_addl_t']
-      @additional_authors = @document['author_addl_t']
+    @additional_authors = @document['author_addl_t'] if @document['author_addl_t']
+  end
+
+  private
+
+  def branding
+    library = begin
+      Library.find_by!(short_code: params[:lib])
+    rescue ActiveRecord::RecordNotFound
+      Library.find_by!(short_code: 'neos')
     end
+    $brand = library.short_code
+    $libraryname = library.name
+    $homeurl = library.url
+    $neosurl = library.neos_url
   end
 
   configure_blacklight do |config|
@@ -297,4 +293,4 @@ class CatalogController < ApplicationController
     config.autocomplete_enabled = true
     config.autocomplete_path = 'suggest'
   end
-    end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module SearchApp
-  VERSION = '1.0.69'.freeze # used in application layout meta generator tag
+  VERSION = '1.0.70'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
Alberta Innovates asked about branding flipping on the advanced search page.  I confirmed this behaviour.

I refactored the branding code into its own method and use the before action callback to ensure that this setup is done on every actions.

Also bump CHANGELOG and VERSION for 1.0.70 release .