### PR TITLE
Disable suggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+### Removed
+- Disable suggest [#562](https://github.com/ualbertalib/NEOSDiscovery/issues/562)
+
 ## [1.0.72] - 2022-02-01
 
 ### Changed

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -285,12 +285,6 @@ class CatalogController < ApplicationController
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'
     config.add_sort_field 'title_sort asc, pub_date_sort desc', label: 'title'
 
-    # If there are more than this many search results, no spelling ("did you
-    # mean") suggestion is offered.
-    config.spell_max = 5
 
-    # Configuration for autocomplete suggestor
-    config.autocomplete_enabled = true
-    config.autocomplete_path = 'suggest'
   end
 end


### PR DESCRIPTION
We don't have the proper request handler enabled on the [Solr side](https://github.com/ualbertalib/blacklight_solr_conf) for this to work. https://solr.apache.org/guide/6_6/suggester.html

This feature has never worked but a change in RSolr is causing a new 404 error which is making Rollbar extra noisy on the last release.
```
Started GET "/suggest?q=climate%20change" for 127.0.0.1 at 2022-02-02 13:26:17 -0700
Processing by SuggestController#index as JSON
  Parameters: {"q"=>"climate change"}
Completed 500 Internal Server Error in 11ms (ActiveRecord: 0.0ms)



RSolr::Error::Http - RSolr::Error::Http - 404 Not Found
Error:     Not Found
URI: http://localhost:8983/solr/discovery/suggest?wt=json&q=climate+change
Backtrace: /home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/rsolr-2.4.0/lib/rsolr/client.rb:220:in `rescue in execute'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/rsolr-2.4.0/lib/rsolr/client.rb:208:in `execute'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/rsolr-2.4.0/lib/rsolr/client.rb:203:in `send_and_receive'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/blacklight-6.10.1/app/models/blacklight/suggest_search.rb:25:in `suggest_results'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/blacklight-6.10.1/app/models/blacklight/suggest_search.rb:18:in `suggestions'
/home/pjenkins/Code/ualbertalib/NEOSDiscovery/app/controllers/concerns/blacklight/suggest.rb:22:in `suggestions_service'
/home/pjenkins/Code/ualbertalib/NEOSDiscovery/app/controllers/concerns/blacklight/suggest.rb:16:in `block (2 levels) in index'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/mime_responds.rb:203:in `respond_to'
/home/pjenkins/Code/ualbertalib/NEOSDiscovery/app/controllers/concerns/blacklight/suggest.rb:14:in `index'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/home/pjenkins/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/base.rb:194:in `process_action':
  app/controllers/concerns/blacklight/suggest.rb:22:in `suggestions_service'
  app/controllers/concerns/blacklight/suggest.rb:16:in `block (2 levels) in index'
  app/controllers/concerns/blacklight/suggest.rb:14:in `index'
```


#563 