### PR TITLE
Revert "Bump sdoc from 2.3.1 to 2.4.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'devise-guests', '~> 0.8'
 gem 'rollbar'
 
 # bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 2.4.0', group: :doc
+gem 'sdoc', '~> 2.3.1', group: :doc
 
 group :development, :test do
   gem 'rspec-rails', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,8 +183,6 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    psych (4.0.3)
-      stringio
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3.1)
@@ -218,8 +216,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.4.0)
-      psych (>= 4.0.0)
+    rdoc (6.3.3)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -256,8 +253,8 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    sdoc (2.4.0)
-      rdoc (>= 5.0)
+    sdoc (2.3.1)
+      rdoc (>= 5.0, < 6.4.0)
     slop (3.6.0)
     spring (2.1.1)
     sprockets (4.0.3)
@@ -268,7 +265,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
-    stringio (3.0.2)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -340,7 +336,7 @@ DEPENDENCIES
   rsolr (~> 2.5)
   rspec-rails (~> 5.1)
   sassc-rails (~> 2.1)
-  sdoc (~> 2.4.0)
+  sdoc (~> 2.3.1)
   spring
   sprockets (< 5.0)
   sqlite3 (~> 1.4.2)


### PR DESCRIPTION
Reverts ualbertalib/NEOSDiscovery#593

Introduced error: `visit_Psych_Nodes_Alias': Unknown alias: default (Psych::BadAlias)`

```
cce47c30da1a57f03898a21f7c3d5b4eb80733b3 is the first bad commit
commit cce47c30da1a57f03898a21f7c3d5b4eb80733b3
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Jun 8 09:19:36 2022 -0600

    Bump sdoc from 2.3.1 to 2.4.0 (#593)
    
    Bumps [sdoc](https://github.com/zzak/sdoc) from 2.3.1 to 2.4.0.
    - [Release notes](https://github.com/zzak/sdoc/releases)
    - [Changelog](https://github.com/zzak/sdoc/blob/master/CHANGELOG.md)
    - [Commits](https://github.com/zzak/sdoc/commits)
    
    ---
    updated-dependencies:
    - dependency-name: sdoc
      dependency-type: direct:development
      update-type: version-update:semver-minor
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>
    
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

 Gemfile      |  2 +-
 Gemfile.lock | 12 ++++++++----
 2 files changed, 9 insertions(+), 5 deletions(-)
```