### PR TITLE
Address regression from rails 5.2.8.1 upgrade impacting serialization the Search model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [1.0.75] - 2022-07-21
 ### Fixed 
-- Address regression from rails 5.2.8.1 upgrade impacting storage of ActiveSupport::HashWithIndifferentAccess yaml serializations (specifically the Search model in Blacklight) 
+- Address regression from the Rails 5.2.8.1 upgrade impacting storage of ActiveSupport::HashWithIndifferentAccess yaml serializations (that impacts the Search model in Blacklight) 
 
 ## [1.0.74] - 2022-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and releases in NEOSDiscovery project adheres to [Semantic Versioning](http://se
 
 ## [Unreleased]
 
+## [1.0.75] - 2022-07-21
+### Fixed 
+- Address regression from rails 5.2.8.1 upgrade impacting storage of ActiveSupport::HashWithIndifferentAccess yaml serializations (specifically the Search model in Blacklight) 
+
 ## [1.0.74] - 2022-07-13
 
 ### Security

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,9 @@ module SearchApp
     config.symphony_timeout = 4
 
     config.active_record.sqlite3.represent_boolean_as_integer = true
+    
+    # 5.2.8.1 necessitatied specification of permitted classes as part of 
+    # https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
+    config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess, Symbol]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module SearchApp
 
     config.active_record.sqlite3.represent_boolean_as_integer = true
     
-    # 5.2.8.1 necessitatied specification of permitted classes as part of 
+    # Rails 5.2.8.1 necessitates the specification of permitted classes as part of 
     # https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess, Symbol]
   end


### PR DESCRIPTION
Rails 5.2.8.1 necessitated the specification of permitted classes as part of <https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017>

This PR addresses the  regression from the Rails 5.2.8.1 upgrade impacting storage of ActiveSupport::HashWithIndifferentAccess yaml serializations (that impacts the Search model in Blacklight). 

From @pgwillia via Slack @ 2022-07-20: 
> [Blacklight has a "fix"](https://github.com/projectblacklight/blacklight/pull/2772/files)  that they even backported to the 6.x version we're using which deems `ActiveSupport::HashWithIndifferentAccess` and `Symbol` as "safe" classes for serialization.  Unfortunately we're stuck on blacklight 6.10.1 because newer versions introduce a bug in how our email form is presented.